### PR TITLE
Update headers.tex - note misspelling of referer

### DIFF
--- a/headers.tex
+++ b/headers.tex
@@ -79,7 +79,7 @@
             Origin & Used for initiating CORS requests & \header{Origin: http://jesusabdullah.net } \\
             Pragma & Directives which may or may not have effects anywhere along the request/response chain & \header{Pragma: no-cache } \\
             Range & Request only parts of an entity (used for resuming downloads) & \header{Range: bytes=136-1337} \\
-            Referer & The address of the web page which had the link followed by the client & \header{Referer: http://jesusabdullah.net } \\
+            Referer & The address of the web page which had the link followed by the client (note misspelling of referrer) & \header{Referer: http://jesusabdullah.net } \\
             TE & Transfer encodings the client is willing to accept, including trailers (used in chunked transfer encodings) & \header{TE: trailers, deflate } \\
             Upgrade & Request that the server upgrade to another protocol & \header{Upgrade: websocket } \\
             User-Agent & The user agent string of the client & \header{User-Agent: curl/7.22.0 (x86\_64-pc-linux-gnu)} \header{libcurl/7.22.0 OpenSSL/1.0.1 zlib/1.2.3.4} \header{libidn/1.23 librtmp/2.3} \\


### PR DESCRIPTION
I was always forgetting referrer is misspelt referer. 

Sorry don't have tools to generate PDF
