### PR TITLE
Removed duplicated pdf generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ clean:
 %.pdf: %.tex
 	@echo "# Generating $@ from $<..."
 	pdflatex -shell-escape -interaction=nonstopmode -halt-on-error $<
-	pdflatex -shell-escape -interaction=nonstopmode -halt-on-error $<
 
 thumbnails:
 	@mkdir -p thumbnails


### PR DESCRIPTION
It's ok to run the command only once.

And by the way, is it better to use `xelatex` than `pdflatex` ?
